### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -10,6 +10,10 @@ on:
         description: "Specify the build script to run"
         required: false
         default: "npm run build"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: read
@@ -24,3 +28,4 @@ jobs:
     with:
       tag: "${{ github.event.inputs.tag }}"
       script: "${{ github.event.inputs.script }}"
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit_package.yml
+++ b/.github/workflows/audit_package.yml
@@ -15,7 +15,11 @@ on:
         description: "Specify the build script to run"
         required: false
         type: string
-        default: "npm run build"        
+        default: "npm run build"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
   schedule:
     - cron: "0 0 * * 1"
@@ -26,6 +30,7 @@ jobs:
     with:
       base_branch: ${{ github.event.inputs.base_branch || 'main' }}
       script: ${{ github.event.inputs.script || 'yarn build' }}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -15,6 +15,10 @@ on:
         description: "Run mode: cherry-pick or verify"
         required: false
         default: "cherry-pick"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
   pull_request:
     types: [opened, synchronize, labeled]
@@ -35,4 +39,5 @@ jobs:
       package_manager: "yarn"
       script: ${{ inputs.script || 'npm run build' }}
       mode: ${{ github.event_name == 'pull_request' && 'verify' || inputs.mode }}
+      node_version: "${{ inputs.node_version || '24' }}"
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Github Action for sending message (and reactions/threads/update/blocks) to Slack
 
 — With support for Slack's optional arguments

--- a/dist/index.js
+++ b/dist/index.js
@@ -35935,6 +35935,8 @@ module.exports = { apiPostMessage, apiAddReaction, apiUpdateMessage };
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const axios = __nccwpck_require__(7269);
+const fs = __nccwpck_require__(9896);
+const core = __nccwpck_require__(7484);
 const context = __nccwpck_require__(4270);
 const { postMessage } = __nccwpck_require__(57);
 const { addReaction } = __nccwpck_require__(8725);
@@ -35943,19 +35945,48 @@ const { updateMessage } = __nccwpck_require__(4217);
 const jsonPretty = (data) => JSON.stringify(data, undefined, 2);
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = "archive/github-actions-slack";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  core.info("");
+  core.info("[1;36mStepSecurity Maintained Action[0m");
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info("[32m✓ Free for public repositories[0m");
+  core.info(`[36mLearn more:[0m ${docsUrl}`);
+  core.info("");
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body = { action: action || "" };
+
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, {timeout: 3000});
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
-    if (error.response && error.response.status === 403) {
-      console.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      core.error(
+        `[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`,
+      );
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`,
       );
       process.exit(1);
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.');
     }
+    core.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 

--- a/src/invoke.js
+++ b/src/invoke.js
@@ -1,4 +1,6 @@
 const axios = require('axios');
+const fs = require('fs');
+const core = require('@actions/core');
 const context = require("./context");
 const { postMessage } = require("./message");
 const { addReaction } = require("./reaction");
@@ -7,19 +9,48 @@ const { updateMessage } = require("./update-message");
 const jsonPretty = (data) => JSON.stringify(data, undefined, 2);
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = "archive/github-actions-slack";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  core.info("");
+  core.info("[1;36mStepSecurity Maintained Action[0m");
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info("[32m✓ Free for public repositories[0m");
+  core.info(`[36mLearn more:[0m ${docsUrl}`);
+  core.info("");
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body = { action: action || "" };
+
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, {timeout: 3000});
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
-    if (error.response && error.response.status === 403) {
-      console.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      core.error(
+        `[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`,
+      );
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`,
       );
       process.exit(1);
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.');
     }
+    core.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260507T035930Z